### PR TITLE
SECD-740 Allow Nexpose assets with IP, hostname, or both

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,9 +29,15 @@ services:
       NEXPOSEASSETATTRIBUTOR_CLOUDASSETINVENTORY_ENDPOINT:
       NEXPOSEASSETATTRIBUTOR_CLOUDASSETINVENTORY_HTTPCLIENT_TYPE: "default"
       NEXPOSEASSETATTRIBUTOR_CLOUDASSETINVENTORY_HTTPCLIENT_SMART_OPENAPI: ""
-  gateway:
+  gateway-incoming:
     build:
       context: .
-      dockerfile: gateway.Dockerfile
+      dockerfile: gateway-incoming.Dockerfile
     ports:
       - "8080:8080"
+  gateway-outgoing:
+    build:
+      context: .
+      dockerfile: gateway-outgoing.Dockerfile
+    ports:
+      - "8082:8082"

--- a/gateway-incoming.Dockerfile
+++ b/gateway-incoming.Dockerfile
@@ -1,0 +1,3 @@
+FROM asecurityteam/serverfull-gateway
+COPY gateway-incoming.yaml .
+ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="gateway-incoming.yaml"

--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -59,14 +59,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AssetWithVulnerabilities'
+              anyOf:
+                # an asset needs either a hostname OR an IP (or both)
+                - $ref: '#/components/schemas/AssetVulnerabilitiesWithIP'
+                - $ref: '#/components/schemas/AssetVulnerabilitiesWithHostname'
       responses:
-        "200":
+        "204":
           description: "Success"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssetWithVulnerabilitiesAndBusinessContext'
         "400":
             description: "Invalid input"
             content:
@@ -90,7 +89,7 @@ paths:
           arn: "attribute"
           async: false
           request: '#! json .Request.Body !#'
-          success: '{"status": 200, "bodyPassthrough": true}'
+          success: '{"status": 204, "bodyPassthrough": true}'
           error: >
             {
               "status":
@@ -123,7 +122,7 @@ components:
         reason:
           type: string
           description: Detailed information about the error
-    AssetWithVulnerabilities:
+    AssetVulnerabilitiesWithIP:
       type: object
       required:
         - id
@@ -131,10 +130,6 @@ components:
         - lastScanned
         - assetVulnerabilityDetails
       properties:
-        hostname:
-          type: string
-          example: corporate-workstation-1102DC.acme.com
-          description: The primary host name (local or FQDN) of the asset.
         id:
           type: integer
           format: int64
@@ -144,6 +139,32 @@ components:
           type: string
           example: 182.34.74.202
           description: The primary IPv4 or IPv6 address of the asset.
+        lastScanned:
+          type: string
+          format: date-time
+          description: The last time the asset was scanned.
+        assetVulnerabilityDetails:
+          type: array
+          description: List of vulnerabilities found on the asset.
+          items:
+            $ref: '#/components/schemas/AssetVulnerabilityDetails'
+    AssetVulnerabilitiesWithHostname:
+      type: object
+      required:
+        - id
+        - hostname
+        - lastScanned
+        - assetVulnerabilityDetails
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 282
+          description: The identifier of the asset.
+        hostname:
+          type: string
+          example: corporate-workstation-1102DC.acme.com
+          description: The primary host name (local or FQDN) of the asset.
         lastScanned:
           type: string
           format: date-time
@@ -225,79 +246,3 @@ components:
             - esp
             - nd
             - raw
-    BusinessContext:
-      type: object
-      description: The "real world" aspects of the asset helpful for assigning remediations to teams and people.
-      properties:
-        privateIPAddresses:
-          type: array
-          description: All private IP addresses attached to the asset.
-          items:
-            type: string
-        publicIPAddresses:
-          type: array
-          description: All public IP addresses attached to the asset.
-          items:
-            type: string
-        hostnames:
-          type: array
-          description: All hostnames attached to the asset.
-          items:
-            type: string
-        resourceType:
-          type: string
-          description: The type of device.
-          example: "ec2:instance"
-        accountID:
-          type: string
-          description: Account ID associated with the asset, if applicable.
-          example: "8675309"
-        region:
-          type: string
-          description: Region where the asset is deployed.
-          example: "us-west"
-        resourceID:
-          type: string
-          description: Identifier for this asset that may be different from its Nexpose identified.
-          example: "arn:aws:a4b:us-east-1:123456789012:room/7315ffdf0eeb874dc4ab8a546e8b70ec/5f90e5d608b6baa9c88db56654aef158"
-        tags:
-          type: object
-          description: Freeform tags attached to the asset in an asset inventory system
-          additionalProperties:
-            type: string
-          example:
-            resource_owner: "service_owner@example.com"
-            business_unit: "Acme Product Team"
-            service_name: "example_service"
-    AssetWithVulnerabilitiesAndBusinessContext:
-      type: object
-      required:
-        - id
-        - ip
-        - lastScanned
-        - assetVulnerabilityDetails
-      properties:
-        hostname:
-          type: string
-          example: corporate-workstation-1102DC.acme.com
-          description: The primary host name (local or FQDN) of the asset.
-        id:
-          type: integer
-          format: int64
-          example: 282
-          description: The identifier of the asset.
-        ip:
-          type: string
-          example: 182.34.74.202
-          description: The primary IPv4 or IPv6 address of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
-        assetVulnerabilityDetails:
-          type: array
-          description: List of vulnerabilities found on the asset.
-          items:
-            $ref: '#/components/schemas/AssetVulnerabilityDetails'
-        businessContext:
-          $ref: '#/components/schemas/BusinessContext'

--- a/gateway-outgoing.Dockerfile
+++ b/gateway-outgoing.Dockerfile
@@ -1,3 +1,3 @@
 FROM asecurityteam/serverfull-gateway
-COPY gateway-incoming.yaml .
-ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="gateway-incoming.yaml"
+COPY gateway-outgoing.yaml .
+ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="gateway-outgoing.yaml"

--- a/gateway-outgoing.Dockerfile
+++ b/gateway-outgoing.Dockerfile
@@ -1,0 +1,3 @@
+FROM asecurityteam/serverfull-gateway
+COPY gateway-incoming.yaml .
+ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="gateway-incoming.yaml"

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -1,0 +1,308 @@
+openapi: 3.0.0
+x-runtime:
+  httpserver:
+    address: ":8082"
+  logger:
+    level: "INFO"
+    output: "STDOUT"
+  stats:
+    output: "NULL"
+  signals:
+    installed:
+      - "OS"
+    os:
+      signals:
+        - 2 # SIGINT
+        - 15 # SIGTERM
+  connstate:
+    reportinterval: "5s"
+    hijackedcounter: "http.server.connstate.hijacked"
+    closedcounter: "http.server.connstate.closed"
+    idlegauge: "http.server.connstate.idle.gauge"
+    idlecounter: "http.server.connstate.idle"
+    activegauge: "http.server.connstate.active.gauge"
+    activecounter: "http.server.connstate.active"
+    newgauge: "http.server.connstate.new.gauge"
+    newcounter: "http.server.connstate.new"
+x-transportd:
+  backends:
+    - queue
+  queue:
+    host: "${HTTPPRODUCER_API_HOST}"
+    pool:
+      ttl: "15m"
+      count: 1
+info:
+  version: 1.0.0
+  title: "nexpose-asset-attributor outgoing calls"
+  description: "Attribute Assets from Nexpose to Teams and People"
+  contact:
+    name: Security Development
+    email: secdev-external@atlassian.com
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /publish:
+    post:
+      summary: "Produce an attributed asset"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              anyOf:
+                # an asset needs either a hostname OR an IP (or both)
+                - $ref: '#/components/schemas/AssetWithIPVulnerabilitiesAndBusinessContext'
+                - $ref: '#/components/schemas/AssetWithHostnameVulnerabilitiesAndBusinessContext'
+      responses:
+        "200":
+          description: "Success"
+        "400":
+          description: "Invalid input"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      x-transportd:
+        backend: queue
+        enabled:
+          - "accesslog"
+          - "metrics"
+          - "requestvalidation"
+          - "timeout"
+          - "retry"
+        timeout:
+          after: "5s"
+        retry:
+          backoff: "50ms"
+          limit: 3
+          codes:
+            - 500
+            - 501
+            - 502
+            - 503
+            - 504
+            - 505
+            - 506
+            - 507
+            - 508
+            - 509
+            - 510
+            - 511
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        status:
+          type: string
+          description: HTTP status message
+        code:
+          type: integer
+          description: HTTP status code
+        reason:
+          type: string
+          description: Detailed information about the error
+    AssetWithVulnerabilities:
+      type: object
+      required:
+        - id
+        - ip
+        - lastScanned
+        - assetVulnerabilityDetails
+      properties:
+        hostname:
+          type: string
+          example: corporate-workstation-1102DC.acme.com
+          description: The primary host name (local or FQDN) of the asset.
+        id:
+          type: integer
+          format: int64
+          example: 282
+          description: The identifier of the asset.
+        ip:
+          type: string
+          example: 182.34.74.202
+          description: The primary IPv4 or IPv6 address of the asset.
+        lastScanned:
+          type: string
+          format: date-time
+          description: The last time the asset was scanned.
+        assetVulnerabilityDetails:
+          type: array
+          description: List of vulnerabilities found on the asset.
+          items:
+            $ref: '#/components/schemas/AssetVulnerabilityDetails'
+    AssetVulnerabilityDetails:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: ssh-openssh-x11uselocalhost-x11-forwarding-session-hijack
+          description: The identifier of the vulnerability.
+        results:
+          type: array
+          description: >-
+            The vulnerability check results for the finding. Multiple instances
+            may be present if one or more checks fired, or a check has multiple
+            independent results.
+          items:
+            $ref: '#/components/schemas/AssessmentResult'
+        cvssV2Score:
+          type: number
+          format: double
+          example: 4.4
+          description: 'The CVSS V2 score, which ranges from 0-10.'
+        cvssV2Severity:
+          type: string
+          example: Severe
+          description: >-
+            The severity of the vulnerability, one of: `"Moderate"`, `"Severe"`,
+            `"Critical"`.
+        description:
+          type: string
+          example: >-
+            <p>A remote code execution vulnerability exists in the way that the
+            scripting engine handles objects in memory in Microsoft Edge. ...</p>
+          description: The description of the vulnerability.
+        title:
+          type: string
+          example: >-
+            Microsoft CVE-2017-11804: Scripting Engine Memory Corruption
+            Vulnerability
+          description: The title (summary) of the vulnerability.
+        solutions:
+          type: array
+          items:
+            type: string
+          description: Solutions for remediation of the vulnerability.
+    AssessmentResult:
+      type: object
+      required:
+        - port
+        - protocol
+      properties:
+        port:
+          type: integer
+          format: int32
+          example: 22
+          description: The port of the service the result was discovered on.
+        protocol:
+          type: string
+          example: tcp
+          description: The protocol of the service the result was discovered on.
+          enum:
+            - ip
+            - icmp
+            - igmp
+            - ggp
+            - tcp
+            - pup
+            - udp
+            - idp
+            - esp
+            - nd
+            - raw
+    BusinessContext:
+      type: object
+      description: The "real world" aspects of the asset helpful for assigning remediations to teams and people.
+      properties:
+        privateIPAddresses:
+          type: array
+          description: All private IP addresses attached to the asset.
+          items:
+            type: string
+        publicIPAddresses:
+          type: array
+          description: All public IP addresses attached to the asset.
+          items:
+            type: string
+        hostnames:
+          type: array
+          description: All hostnames attached to the asset.
+          items:
+            type: string
+        resourceType:
+          type: string
+          description: The type of device.
+          example: "ec2:instance"
+        accountID:
+          type: string
+          description: Account ID associated with the asset, if applicable.
+          example: "8675309"
+        region:
+          type: string
+          description: Region where the asset is deployed.
+          example: "us-west"
+        resourceID:
+          type: string
+          description: Identifier for this asset that may be different from its Nexpose identified.
+          example: "arn:aws:a4b:us-east-1:123456789012:room/7315ffdf0eeb874dc4ab8a546e8b70ec/5f90e5d608b6baa9c88db56654aef158"
+        tags:
+          type: object
+          description: Freeform tags attached to the asset in an asset inventory system
+          additionalProperties:
+            type: string
+          example:
+            resource_owner: "service_owner@example.com"
+            business_unit: "Acme Product Team"
+            service_name: "example_service"
+    AssetWithIPVulnerabilitiesAndBusinessContext:
+      type: object
+      required:
+        - id
+        - ip
+        - lastScanned
+        - assetVulnerabilityDetails
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 282
+          description: The identifier of the asset.
+        ip:
+          type: string
+          example: 182.34.74.202
+          description: The primary IPv4 or IPv6 address of the asset.
+        lastScanned:
+          type: string
+          format: date-time
+          description: The last time the asset was scanned.
+        assetVulnerabilityDetails:
+          type: array
+          description: List of vulnerabilities found on the asset.
+          items:
+            $ref: '#/components/schemas/AssetVulnerabilityDetails'
+        businessContext:
+          $ref: '#/components/schemas/BusinessContext'
+    AssetWithHostnameVulnerabilitiesAndBusinessContext:
+      type: object
+      required:
+        - id
+        - hostname
+        - lastScanned
+        - assetVulnerabilityDetails
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 282
+          description: The identifier of the asset.
+        hostname:
+          type: string
+          example: corporate-workstation-1102DC.acme.com
+          description: The primary host name (local or FQDN) of the asset.
+        lastScanned:
+          type: string
+          format: date-time
+          description: The last time the asset was scanned.
+        assetVulnerabilityDetails:
+          type: array
+          description: List of vulnerabilities found on the asset.
+          items:
+            $ref: '#/components/schemas/AssetVulnerabilityDetails'
+        businessContext:
+          $ref: '#/components/schemas/BusinessContext'

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -68,7 +68,6 @@ paths:
         backend: queue
         enabled:
           - "accesslog"
-          - "metrics"
           - "requestvalidation"
           - "timeout"
           - "retry"

--- a/gateway.Dockerfile
+++ b/gateway.Dockerfile
@@ -1,3 +1,0 @@
-FROM asecurityteam/serverfull-gateway
-COPY api.yaml .
-ENV TRANSPORTD_OPENAPI_SPECIFICATION_FILE="api.yaml"


### PR DESCRIPTION
Valid Nexpose assets can have an IP, a hostname, or both.
* Update the API specs to support this case.
* Split incoming/outgoing call API specs
* Add missing /publish endpoint in the outgoing gateway API spec.
* Update API spec to return 204 status code and no body.