### PR TITLE
Improve coverage cloudassetinventory

### DIFF
--- a/pkg/assetattributor/cloudassetinventory_test.go
+++ b/pkg/assetattributor/cloudassetinventory_test.go
@@ -60,6 +60,14 @@ func TestCloudAssetInventoryComponent_ParseURL(t *testing.T) {
 	}
 }
 
+func TestCloudAssetInventoryComponent_NewConfigError(t *testing.T) {
+	c := NewCloudAssetInventoryComponent()
+	config := c.Settings()
+	config.HTTP.Type = "UNKNOWN"
+	_, err := c.New(context.Background(), config)
+	require.Error(t, err)
+}
+
 func TestCloudAssetInventory_Attribute(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/assetattributor/cloudassetinventory_test.go
+++ b/pkg/assetattributor/cloudassetinventory_test.go
@@ -22,6 +22,11 @@ var testHostname = "hostname"
 var testTimestamp = time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC)
 var errReason = ""
 
+func TestCloudAssetInventoryConfigName(t *testing.T) {
+	cloudAssetInventoryConfig := CloudAssetInventoryConfig{}
+	require.Equal(t, "CloudAssetInventory", cloudAssetInventoryConfig.Name())
+}
+
 func TestCloudAssetInventoryComponent_ParseURL(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
-added a test to test Name()
-added a test to test CloudAssetInventoryComponent, specifically *httpclient.Component.New()
In order to do this, we define an interface that *httpclient.Component can implement. We can then mockgen this interface, which allows the ability to mock this functionality and force an error.
- 100% coverage
