### PR TITLE
PSD-99 Add 'proof' field to AssessmentResults

### DIFF
--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -250,3 +250,6 @@ components:
             - esp
             - nd
             - raw
+        proof:
+          type: string
+          description: The proof explaining why the result was found vulnerable.

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -209,6 +209,9 @@ components:
             - esp
             - nd
             - raw
+        proof:
+          type: string
+          description: The proof explaining why the result was found vulnerable.
     BusinessContext:
       type: object
       description: The "real world" aspects of the asset helpful for assigning remediations to teams and people.

--- a/go.mod
+++ b/go.mod
@@ -67,3 +67,5 @@ require (
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22 // indirect
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/pkg/domain/vulnerability.go
+++ b/pkg/domain/vulnerability.go
@@ -17,4 +17,5 @@ type AssetVulnerabilityDetails struct {
 type AssessmentResult struct {
 	Port     int    `json:"port"`
 	Protocol string `json:"protocol"`
+	Proof    string `json:"proof"`
 }


### PR DESCRIPTION
This change adds the "proof" field to our incoming and outgoing Vulnerability Details so we can expose "proof" information in Nexpose VULN tickets.