### PR TITLE
response validation is failing, probably due to 'null'

### DIFF
--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -25,21 +25,21 @@ type NexposeAssetVulnerabilities struct {
 
 // CloudAssetDetails represent a cloud asset and associated metadata
 type CloudAssetDetails struct {
-	PrivateIPAddresses []string          `json:"privateIPAddresses"`
-	PublicIPAddresses  []string          `json:"publicIPAddresses"`
-	Hostnames          []string          `json:"hostnames"`
-	ResourceType       string            `json:"resourceTypes"`
-	AccountID          string            `json:"accountID"`
-	Region             string            `json:"region"`
-	ARN                string            `json:"arn"`
-	Tags               map[string]string `json:"tags"`
+	PrivateIPAddresses []string          `json:"privateIPAddresses,omitempty"`
+	PublicIPAddresses  []string          `json:"publicIPAddresses,omitempty"`
+	Hostnames          []string          `json:"hostnames,omitempty"`
+	ResourceType       string            `json:"resourceTypes,omitempty"`
+	AccountID          string            `json:"accountID,omitempty"`
+	Region             string            `json:"region,omitempty"`
+	ARN                string            `json:"arn,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
 }
 
 // NexposeAttributedAssetVulnerabilities is a NexposeAssetVulnerabilities instance combined
 // with the business context pertaining to the asset at scan time.
 type NexposeAttributedAssetVulnerabilities struct {
 	NexposeAssetVulnerabilities
-	BusinessContext CloudAssetDetails `json:"businessContext"`
+	BusinessContext CloudAssetDetails `json:"businessContext,omitempty"`
 }
 
 // AssetNotFoundError occurs when a request to an asset inventory system


### PR DESCRIPTION
Logs are showing a response validation violation, most likely due to the response validator failing to type check `null`. 

Error message:
```
{"code":502,"status":"Bad Gateway","reason":"response body doesn't match the schema: Error at \"/asset\":Doesn't match schema \"anyOf\"\nSchema:\n  {\n    \"anyOf\": [\n      {\n        \"$ref\": \"#/components/schemas/AssetWithVulnerabilitiesAndBusinessContextWithIP\"\n      },\n      {\n        \"$ref\": \"#/components/schemas/AssetWithVulnerabilitiesAndBusinessContextWithHostname\"\n      }\n    ],\n    \"description\": \"The asset with its vulnerabilities and business context with either the ip or hostname.\",\n    \"type\": \"object\"\n  }\n\nValue:\n  {\n    \"assetVulnerabilityDetails\": [],\n    \"businessContext\": {\n      \"accountID\": \"\",\n      \"arn\": \"\",\n      \"hostnames\": null,\n      \"privateIPAddresses\": null,\n      \"publicIPAddresses\": null,\n      \"region\": \"\",\n      \"resourceTypes\": \"\",\n      \"tags\": null\n    },\n    \"hostname\": \"\",\n    \"id\": 2669492,\n    \"ip\": \"10.117.146.58\",\n    \"lastScanned\": \"2019-09-24T06:19:17.333Z\"\n  }\n"}
```

The open api spec schema declares `hostname` as a string type, but since it's returned as `null`, the validator cannot validate it
```
    BusinessContext:
      type: object
      description: The "real world" aspects of the asset helpful for assigning remediations to teams and people.
      properties:
        ...
        hostnames:
          type: array
          description: All hostnames attached to the asset.
          items:
            type: string
        ...
```