### PR TITLE
Bug/response validation

### DIFF
--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -25,21 +25,21 @@ type NexposeAssetVulnerabilities struct {
 
 // CloudAssetDetails represent a cloud asset and associated metadata
 type CloudAssetDetails struct {
-	PrivateIPAddresses []string          `json:"privateIPAddresses"`
-	PublicIPAddresses  []string          `json:"publicIPAddresses"`
-	Hostnames          []string          `json:"hostnames"`
-	ResourceType       string            `json:"resourceTypes"`
-	AccountID          string            `json:"accountID"`
-	Region             string            `json:"region"`
-	ARN                string            `json:"arn"`
-	Tags               map[string]string `json:"tags"`
+	PrivateIPAddresses []string          `json:"privateIPAddresses,omitempty"`
+	PublicIPAddresses  []string          `json:"publicIPAddresses,omitempty"`
+	Hostnames          []string          `json:"hostnames,omitempty"`
+	ResourceType       string            `json:"resourceTypes,omitempty"`
+	AccountID          string            `json:"accountID,omitempty"`
+	Region             string            `json:"region,omitempty"`
+	ARN                string            `json:"arn,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
 }
 
 // NexposeAttributedAssetVulnerabilities is a NexposeAssetVulnerabilities instance combined
 // with the business context pertaining to the asset at scan time.
 type NexposeAttributedAssetVulnerabilities struct {
 	NexposeAssetVulnerabilities
-	BusinessContext CloudAssetDetails `json:"businessContext"`
+	BusinessContext CloudAssetDetails `json:"businessContext,omitempty"`
 }
 
 // AssetNotFoundError occurs when a request to an asset inventory system

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -2,7 +2,9 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 )
 
@@ -25,21 +27,72 @@ type NexposeAssetVulnerabilities struct {
 
 // CloudAssetDetails represent a cloud asset and associated metadata
 type CloudAssetDetails struct {
-	PrivateIPAddresses []string          `json:"privateIPAddresses,omitempty"`
-	PublicIPAddresses  []string          `json:"publicIPAddresses,omitempty"`
-	Hostnames          []string          `json:"hostnames,omitempty"`
-	ResourceType       string            `json:"resourceTypes,omitempty"`
-	AccountID          string            `json:"accountID,omitempty"`
-	Region             string            `json:"region,omitempty"`
-	ARN                string            `json:"arn,omitempty"`
-	Tags               map[string]string `json:"tags,omitempty"`
+	PrivateIPAddresses []string          `json:"privateIPAddresses"`
+	PublicIPAddresses  []string          `json:"publicIPAddresses"`
+	Hostnames          []string          `json:"hostnames"`
+	ResourceType       string            `json:"resourceTypes"`
+	AccountID          string            `json:"accountID"`
+	Region             string            `json:"region"`
+	ARN                string            `json:"arn"`
+	Tags               map[string]string `json:"tags"`
 }
 
 // NexposeAttributedAssetVulnerabilities is a NexposeAssetVulnerabilities instance combined
 // with the business context pertaining to the asset at scan time.
 type NexposeAttributedAssetVulnerabilities struct {
 	NexposeAssetVulnerabilities
-	BusinessContext CloudAssetDetails `json:"businessContext,omitempty"`
+	BusinessContext CloudAssetDetails `json:"businessContext"`
+}
+
+// UnmarshalJSON is a custom unmarshaller to ensure no `nil` or `null` fields in the resulting struct
+func (n *NexposeAttributedAssetVulnerabilities) UnmarshalJSON(data []byte) error {
+	type Alias NexposeAttributedAssetVulnerabilities
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(n),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if n.NexposeAssetVulnerabilities.Vulnerabilities == nil {
+		n.NexposeAssetVulnerabilities.Vulnerabilities = make([]AssetVulnerabilityDetails, 0)
+	}
+
+	if reflect.DeepEqual((CloudAssetDetails{}), n.BusinessContext) {
+		if err := json.Unmarshal(data, &n.BusinessContext); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalJSON is a custom unmarshaller to ensure no `nil` or `null` fields in the resulting struct
+func (n *CloudAssetDetails) UnmarshalJSON(data []byte) error {
+	type Alias CloudAssetDetails
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(n),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if n.Hostnames == nil {
+		n.Hostnames = make([]string, 0)
+	}
+	if n.PrivateIPAddresses == nil {
+		n.PrivateIPAddresses = make([]string, 0)
+	}
+	if n.PublicIPAddresses == nil {
+		n.PublicIPAddresses = make([]string, 0)
+	}
+	if n.Tags == nil {
+		n.Tags = make(map[string]string)
+	}
+
+	return nil
 }
 
 // AssetNotFoundError occurs when a request to an asset inventory system

--- a/pkg/domain/attributor_test.go
+++ b/pkg/domain/attributor_test.go
@@ -1,0 +1,49 @@
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomUnmarshalling(t *testing.T) {
+	b := []byte(`{"id":1,"hostname":"bowser"}`)
+	partial := NexposeAttributedAssetVulnerabilities{}
+	err := json.Unmarshal(b, &partial)
+	require.Nil(t, err)
+
+	expectedNested := NexposeAssetVulnerabilities{
+		ID:              1,
+		Hostname:        "bowser",
+		Vulnerabilities: make([]AssetVulnerabilityDetails, 0),
+	}
+
+	expected := NexposeAttributedAssetVulnerabilities{
+		NexposeAssetVulnerabilities: expectedNested,
+		BusinessContext: CloudAssetDetails{
+
+			PrivateIPAddresses: make([]string, 0),
+			PublicIPAddresses:  make([]string, 0),
+			Hostnames:          make([]string, 0),
+			Tags:               make(map[string]string),
+		},
+	}
+
+	// kind of a dumb test... but good enough to see
+	marshalled, _ := json.Marshal(partial)
+	badMarshalMsg := "You've added a new field in the struct hierarchy that is type array, slice, or map, but forgot to add custom unmarshalling logic for it"
+	require.False(t, strings.Contains(string(marshalled), "null"), badMarshalMsg)
+
+	fmt.Println(string(marshalled))
+
+	fmt.Println("EXPECTED")
+	fmt.Println(expected)
+	marshalled2, _ := json.Marshal(expected)
+	fmt.Println(string(marshalled2))
+
+	require.True(t, reflect.DeepEqual(expected, partial), "marshalled object does not equal expected object")
+}

--- a/pkg/domain/attributor_test.go
+++ b/pkg/domain/attributor_test.go
@@ -6,11 +6,81 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestCustomUnmarshalling(t *testing.T) {
+func TestCustomUnmarshallingFull(t *testing.T) {
+
+	expectedLastScanned, _ := time.Parse(time.RFC3339Nano, "2019-09-24 18:10:25.19942 -0500 CDT")
+	expectedLastScannedString := expectedLastScanned.Format(time.RFC3339Nano)
+
+	b := []byte(fmt.Sprintf(`{"lastScanned":"%s","hostname":"bowser","id":1,"ip":"9.8.7.6","assetVulnerabilityDetails":[{"id":"a","results":[{"port":3,"protocol":"udp","proof":"I said it"}],"status":"done","cvssV2Score":42,"cvssV2Severity":"uhh, low","description":"it's bad, you know","title":"title here","solutions":["solution"]}],"businessContext":{"privateIPAddresses":["some_private_ip_address"],"publicIPAddresses":["some_public_ip_address"],"hostnames":["some_hostname"],"resourceTypes":"rtype","accountID":"accountId","region":"north","arn":"an_arn","tags":{"tag1":"value1"}}}`, expectedLastScannedString))
+	partial := NexposeAttributedAssetVulnerabilities{}
+	err := json.Unmarshal(b, &partial)
+	require.Nil(t, err)
+
+	expectedNestedAssessmentResults := make([]AssessmentResult, 1)
+	expectedNestedAssessmentResults[0] = AssessmentResult{
+		Port:     3,
+		Protocol: "udp",
+		Proof:    "I said it",
+	}
+
+	expectedNestedAssetVulnerabilityDetailsSolutions := make([]string, 1)
+	expectedNestedAssetVulnerabilityDetailsSolutions[0] = "solution"
+
+	expectedNestedAssetVulnerabilityDetails := make([]AssetVulnerabilityDetails, 1)
+	expectedNestedAssetVulnerabilityDetails[0] = AssetVulnerabilityDetails{
+		ID:             "a",
+		Results:        expectedNestedAssessmentResults,
+		Status:         "done",
+		CvssV2Score:    42,
+		CvssV2Severity: "uhh, low",
+		Description:    "it's bad, you know",
+		Title:          "title here",
+		Solutions:      expectedNestedAssetVulnerabilityDetailsSolutions,
+	}
+
+	expectedNested := NexposeAssetVulnerabilities{
+		ID:              1,
+		Hostname:        "bowser",
+		LastScanned:     expectedLastScanned,
+		IP:              "9.8.7.6",
+		Vulnerabilities: expectedNestedAssetVulnerabilityDetails,
+	}
+
+	expectedPrivateIPAddresses := make([]string, 1)
+	expectedPrivateIPAddresses[0] = "some_private_ip_address"
+
+	expectedPublicIPAddresses := make([]string, 1)
+	expectedPublicIPAddresses[0] = "some_public_ip_address"
+
+	expectedHostnames := make([]string, 1)
+	expectedHostnames[0] = "some_hostname"
+
+	expectedTags := make(map[string]string, 1)
+	expectedTags["tag1"] = "value1"
+
+	expected := NexposeAttributedAssetVulnerabilities{
+		NexposeAssetVulnerabilities: expectedNested,
+		BusinessContext: CloudAssetDetails{
+			PrivateIPAddresses: expectedPrivateIPAddresses,
+			PublicIPAddresses:  expectedPublicIPAddresses,
+			Hostnames:          expectedHostnames,
+			Tags:               expectedTags,
+			ResourceType:       "rtype",
+			AccountID:          "accountId",
+			Region:             "north",
+			ARN:                "an_arn",
+		},
+	}
+
+	require.True(t, reflect.DeepEqual(expected, partial), "marshalled object does not equal expected object")
+}
+
+func TestCustomUnmarshallingEmpty(t *testing.T) {
 	b := []byte(`{"id":1,"hostname":"bowser"}`)
 	partial := NexposeAttributedAssetVulnerabilities{}
 	err := json.Unmarshal(b, &partial)
@@ -37,13 +107,6 @@ func TestCustomUnmarshalling(t *testing.T) {
 	marshalled, _ := json.Marshal(partial)
 	badMarshalMsg := "You've added a new field in the struct hierarchy that is type array, slice, or map, but forgot to add custom unmarshalling logic for it"
 	require.False(t, strings.Contains(string(marshalled), "null"), badMarshalMsg)
-
-	fmt.Println(string(marshalled))
-
-	fmt.Println("EXPECTED")
-	fmt.Println(expected)
-	marshalled2, _ := json.Marshal(expected)
-	fmt.Println(string(marshalled2))
 
 	require.True(t, reflect.DeepEqual(expected, partial), "marshalled object does not equal expected object")
 }


### PR DESCRIPTION
See description from prior attempt:  https://github.com/asecurityteam/nexpose-asset-attributor/pull/18

This PR solves it in a better way in that now the GET responses will always include all fields by having the custom unmarshalling from the DB contents ensure all struct fields are non-nil, with a test to ensure it.  This is desirable over omitting empty fields in the response because the end-consumer (a human) will want to see all fields to simplify the GET/cut/correct/paste/POST workflow.