### PR TITLE
PSD-120 Add the ability to pass the failure to the HandleAttributionFailure function

### DIFF
--- a/pkg/assetattributionfailure/noop.go
+++ b/pkg/assetattributionfailure/noop.go
@@ -11,6 +11,6 @@ type NoopAttributionFailureHandler struct {
 }
 
 // HandleAttributionFailure is a noop implementation
-func (*NoopAttributionFailureHandler) HandleAttributionFailure(ctx context.Context, failedAttributedAsset domain.NexposeAttributedAssetVulnerabilities) error {
+func (*NoopAttributionFailureHandler) HandleAttributionFailure(ctx context.Context, failedAttributedAsset domain.NexposeAttributedAssetVulnerabilities, failure error) error {
 	return nil
 }

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -147,5 +147,5 @@ type AttributionFailureHandler interface {
 	// This method is left to the discretion of the organization. For example, we may want to store their attribution failures encrypted
 	// in a persistent store, while others may want to persist theirs in a long-lived encrypted queue, or rely on a streaming platform
 	// like Kafka to keep the data until it can be investigated.
-	HandleAttributionFailure(ctx context.Context, failedAttributedAsset NexposeAttributedAssetVulnerabilities) error
+	HandleAttributionFailure(ctx context.Context, failedAttributedAsset NexposeAttributedAssetVulnerabilities, failure error) error
 }

--- a/pkg/handlers/v1/attribute.go
+++ b/pkg/handlers/v1/attribute.go
@@ -35,7 +35,7 @@ func (h *AttributeHandler) Handle(ctx context.Context, assetVulns domain.Nexpose
 		default:
 			logger.Error(logs.UnknownAttributionFailureError{Reason: attributionErr.Error()})
 		}
-		err := h.AttributionFailureHandler.HandleAttributionFailure(ctx, domain.NexposeAttributedAssetVulnerabilities{NexposeAssetVulnerabilities: assetVulns})
+		err := h.AttributionFailureHandler.HandleAttributionFailure(ctx, domain.NexposeAttributedAssetVulnerabilities{NexposeAssetVulnerabilities: assetVulns}, attributionErr)
 		if err != nil {
 			return err
 		}
@@ -52,7 +52,7 @@ func (h *AttributeHandler) Handle(ctx context.Context, assetVulns domain.Nexpose
 			logger.Error(logs.AssetValidationError{Reason: validationErr.Error()})
 		}
 
-		failureHandlerErr := h.AttributionFailureHandler.HandleAttributionFailure(ctx, attributedAssetVulns)
+		failureHandlerErr := h.AttributionFailureHandler.HandleAttributionFailure(ctx, attributedAssetVulns, validationErr)
 		if failureHandlerErr != nil {
 			return failureHandlerErr
 		}
@@ -61,7 +61,7 @@ func (h *AttributeHandler) Handle(ctx context.Context, assetVulns domain.Nexpose
 
 	_, producerErr := h.Producer.Produce(ctx, attributedAssetVulns)
 	if producerErr != nil {
-		failureHandlerErr := h.AttributionFailureHandler.HandleAttributionFailure(ctx, attributedAssetVulns)
+		failureHandlerErr := h.AttributionFailureHandler.HandleAttributionFailure(ctx, attributedAssetVulns, producerErr)
 		if failureHandlerErr != nil {
 			return failureHandlerErr
 		}

--- a/pkg/handlers/v1/attribute_test.go
+++ b/pkg/handlers/v1/attribute_test.go
@@ -51,7 +51,7 @@ func TestHandle(t *testing.T) {
 			attributedErr:          domain.AssetNotFoundError{},
 			attributeAndValidateOK: false,
 			AttributionFailureHandlerFunc: func(mockAttributionFailureHandler *MockAttributionFailureHandler) {
-				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any()).Return(nil)
+				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			AttributtedAssetValidationFunc: func(mockAssetValidator *MockAssetValidator) {
 			},
@@ -63,7 +63,7 @@ func TestHandle(t *testing.T) {
 			attributedErr:          domain.AssetInventoryRequestError{},
 			attributeAndValidateOK: false,
 			AttributionFailureHandlerFunc: func(mockAttributionFailureHandler *MockAttributionFailureHandler) {
-				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any()).Return(nil)
+				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			AttributtedAssetValidationFunc: func(mockAssetValidator *MockAssetValidator) {
 			},
@@ -75,7 +75,7 @@ func TestHandle(t *testing.T) {
 			attributedErr:          domain.AssetInventoryMultipleAssetsFoundError{},
 			attributeAndValidateOK: false,
 			AttributionFailureHandlerFunc: func(mockAttributionFailureHandler *MockAttributionFailureHandler) {
-				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any()).Return(nil)
+				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			AttributtedAssetValidationFunc: func(mockAssetValidator *MockAssetValidator) {
 			},
@@ -87,7 +87,7 @@ func TestHandle(t *testing.T) {
 			attributedErr:          errors.New("oh noes"),
 			attributeAndValidateOK: false,
 			AttributionFailureHandlerFunc: func(mockAttributionFailureHandler *MockAttributionFailureHandler) {
-				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any()).Return(nil)
+				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			AttributtedAssetValidationFunc: func(mockAssetValidator *MockAssetValidator) {
 			},
@@ -104,7 +104,7 @@ func TestHandle(t *testing.T) {
 			attributedErr:          nil,
 			attributeAndValidateOK: false,
 			AttributionFailureHandlerFunc: func(mockAttributionFailureHandler *MockAttributionFailureHandler) {
-				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any()).Return(nil)
+				mockAttributionFailureHandler.EXPECT().HandleAttributionFailure(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			AttributtedAssetValidationFunc: func(mockAssetValidator *MockAssetValidator) {
 				mockAssetValidator.EXPECT().Validate(gomock.Any(), gomock.Any()).Return(errors.New("validation error occurred here"))

--- a/pkg/handlers/v1/attributor_mock_test.go
+++ b/pkg/handlers/v1/attributor_mock_test.go
@@ -37,7 +37,6 @@ func (m *MockAssetAttributor) EXPECT() *MockAssetAttributorMockRecorder {
 
 // Attribute mocks base method
 func (m *MockAssetAttributor) Attribute(ctx context.Context, asset domain.NexposeAssetVulnerabilities) (domain.NexposeAttributedAssetVulnerabilities, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Attribute", ctx, asset)
 	ret0, _ := ret[0].(domain.NexposeAttributedAssetVulnerabilities)
 	ret1, _ := ret[1].(error)
@@ -46,7 +45,6 @@ func (m *MockAssetAttributor) Attribute(ctx context.Context, asset domain.Nexpos
 
 // Attribute indicates an expected call of Attribute
 func (mr *MockAssetAttributorMockRecorder) Attribute(ctx, asset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Attribute", reflect.TypeOf((*MockAssetAttributor)(nil).Attribute), ctx, asset)
 }
 
@@ -74,15 +72,13 @@ func (m *MockAttributionFailureHandler) EXPECT() *MockAttributionFailureHandlerM
 }
 
 // HandleAttributionFailure mocks base method
-func (m *MockAttributionFailureHandler) HandleAttributionFailure(ctx context.Context, failedAttributedAsset domain.NexposeAttributedAssetVulnerabilities) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleAttributionFailure", ctx, failedAttributedAsset)
+func (m *MockAttributionFailureHandler) HandleAttributionFailure(ctx context.Context, failedAttributedAsset domain.NexposeAttributedAssetVulnerabilities, failure error) error {
+	ret := m.ctrl.Call(m, "HandleAttributionFailure", ctx, failedAttributedAsset, failure)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleAttributionFailure indicates an expected call of HandleAttributionFailure
-func (mr *MockAttributionFailureHandlerMockRecorder) HandleAttributionFailure(ctx, failedAttributedAsset interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAttributionFailure", reflect.TypeOf((*MockAttributionFailureHandler)(nil).HandleAttributionFailure), ctx, failedAttributedAsset)
+func (mr *MockAttributionFailureHandlerMockRecorder) HandleAttributionFailure(ctx, failedAttributedAsset, failure interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAttributionFailure", reflect.TypeOf((*MockAttributionFailureHandler)(nil).HandleAttributionFailure), ctx, failedAttributedAsset, failure)
 }


### PR DESCRIPTION
This will allow the implementer to handle the failure or take an action based on the failure type. In our specific case, it'll allow us to store the failure or error in the database along with the asset