### PR TITLE
PSD-290 Add ScanTime to schema

### DIFF
--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -127,7 +127,6 @@ components:
       required:
         - id
         - ip
-        - lastScanned
         - assetVulnerabilityDetails
       properties:
         id:
@@ -143,6 +142,10 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned.
+        scanTime:
+          type: string
+          format: date-time
+          description: The time the asset was scanned.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -153,7 +156,6 @@ components:
       required:
         - id
         - hostname
-        - lastScanned
         - assetVulnerabilityDetails
       properties:
         id:
@@ -169,6 +171,10 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned.
+       scanTime:
+          type: string
+          format: date-time
+          description: The time the asset was scanned.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -108,7 +108,6 @@ components:
       required:
         - id
         - ip
-        - lastScanned
         - assetVulnerabilityDetails
       properties:
         hostname:
@@ -128,6 +127,10 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned.
+        scanTime:
+          type: string
+          format: date-time
+          description: The time the asset was scanned.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -261,7 +264,6 @@ components:
       required:
         - id
         - ip
-        - lastScanned
         - assetVulnerabilityDetails
       properties:
         id:
@@ -277,6 +279,10 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned.
+        scanTime:
+          type: string
+          format: date-time
+          description: The time the asset was scanned.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -289,7 +295,6 @@ components:
       required:
         - id
         - hostname
-        - lastScanned
         - assetVulnerabilityDetails
       properties:
         id:
@@ -305,6 +310,10 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned.
+        scanTime:
+          type: string
+          format: date-time
+          description: The time the asset was scanned.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.

--- a/pkg/assetattributor/cloudassetinventory_test.go
+++ b/pkg/assetattributor/cloudassetinventory_test.go
@@ -101,10 +101,10 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 		{
 			name: "success",
 			asset: domain.NexposeAssetVulnerabilities{
-				ID:          1,
-				LastScanned: testTimestamp,
-				IP:          testIP,
-				Hostname:    testHostname,
+				ID:       1,
+				ScanTime: testTimestamp,
+				IP:       testIP,
+				Hostname: testHostname,
 			},
 			resps: []cloudAssetInventoryResponse{
 				{
@@ -125,10 +125,10 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 		{
 			name: "bad request error",
 			asset: domain.NexposeAssetVulnerabilities{
-				ID:          1,
-				LastScanned: testTimestamp,
-				IP:          testIP,
-				Hostname:    testHostname,
+				ID:       1,
+				ScanTime: testTimestamp,
+				IP:       testIP,
+				Hostname: testHostname,
 			},
 			resps: []cloudAssetInventoryResponse{
 				{},
@@ -145,10 +145,10 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 		{
 			name: "multiple assets error",
 			asset: domain.NexposeAssetVulnerabilities{
-				ID:          1,
-				LastScanned: testTimestamp,
-				IP:          testIP,
-				Hostname:    testHostname,
+				ID:       1,
+				ScanTime: testTimestamp,
+				IP:       testIP,
+				Hostname: testHostname,
 			},
 			resps: []cloudAssetInventoryResponse{
 				{
@@ -170,10 +170,10 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 		{
 			name: "multiple non-fatal errors",
 			asset: domain.NexposeAssetVulnerabilities{
-				ID:          1,
-				LastScanned: testTimestamp,
-				IP:          testIP,
-				Hostname:    testHostname,
+				ID:       1,
+				ScanTime: testTimestamp,
+				IP:       testIP,
+				Hostname: testHostname,
 			},
 			resps: []cloudAssetInventoryResponse{
 				{},
@@ -216,10 +216,10 @@ func TestCloudAssetInventory_Attribute_InvalidAssetTimestamp(t *testing.T) {
 	}
 
 	testAsset := domain.NexposeAssetVulnerabilities{
-		ID:          1,
-		LastScanned: time.Time{},
-		IP:          testIP,
-		Hostname:    testHostname,
+		ID:       1,
+		ScanTime: time.Time{},
+		IP:       testIP,
+		Hostname: testHostname,
 	}
 	_, err := attributor.Attribute(context.Background(), testAsset)
 	require.Error(t, err)
@@ -237,8 +237,8 @@ func TestCloudAssetInventory_Attribute_NoHostnameOrIP(t *testing.T) {
 	}
 
 	testAsset := domain.NexposeAssetVulnerabilities{
-		ID:          1,
-		LastScanned: time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+		ID:       1,
+		ScanTime: time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
 	}
 
 	_, err := attributor.Attribute(context.Background(), testAsset)

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -19,6 +19,7 @@ type AssetAttributor interface {
 // with assetVulnerabilityDetails
 type NexposeAssetVulnerabilities struct {
 	LastScanned     time.Time                   `json:"lastScanned"`
+	ScanTime        time.Time                   `json:"scanTime"`
 	Hostname        string                      `json:"hostname"`
 	ID              int64                       `json:"id"`
 	IP              string                      `json:"ip"`

--- a/pkg/domain/attributor_test.go
+++ b/pkg/domain/attributor_test.go
@@ -16,7 +16,7 @@ func TestCustomUnmarshallingFull(t *testing.T) {
 	expectedLastScanned, _ := time.Parse(time.RFC3339Nano, "2019-09-24 18:10:25.19942 -0500 CDT")
 	expectedLastScannedString := expectedLastScanned.Format(time.RFC3339Nano)
 
-	b := []byte(fmt.Sprintf(`{"lastScanned":"%s","hostname":"bowser","id":1,"ip":"9.8.7.6","assetVulnerabilityDetails":[{"id":"a","results":[{"port":3,"protocol":"udp","proof":"I said it"}],"status":"done","cvssV2Score":42,"cvssV2Severity":"uhh, low","description":"it's bad, you know","title":"title here","solutions":["solution"]}],"businessContext":{"privateIPAddresses":["some_private_ip_address"],"publicIPAddresses":["some_public_ip_address"],"hostnames":["some_hostname"],"resourceTypes":"rtype","accountID":"accountId","region":"north","arn":"an_arn","tags":{"tag1":"value1"}}}`, expectedLastScannedString))
+	b := []byte(fmt.Sprintf(`{"scanTime":"%s","hostname":"bowser","id":1,"ip":"9.8.7.6","assetVulnerabilityDetails":[{"id":"a","results":[{"port":3,"protocol":"udp","proof":"I said it"}],"status":"done","cvssV2Score":42,"cvssV2Severity":"uhh, low","description":"it's bad, you know","title":"title here","solutions":["solution"]}],"businessContext":{"privateIPAddresses":["some_private_ip_address"],"publicIPAddresses":["some_public_ip_address"],"hostnames":["some_hostname"],"resourceTypes":"rtype","accountID":"accountId","region":"north","arn":"an_arn","tags":{"tag1":"value1"}}}`, expectedLastScannedString))
 	partial := NexposeAttributedAssetVulnerabilities{}
 	err := json.Unmarshal(b, &partial)
 	require.Nil(t, err)
@@ -46,7 +46,7 @@ func TestCustomUnmarshallingFull(t *testing.T) {
 	expectedNested := NexposeAssetVulnerabilities{
 		ID:              1,
 		Hostname:        "bowser",
-		LastScanned:     expectedLastScanned,
+		ScanTime:        expectedLastScanned,
 		IP:              "9.8.7.6",
 		Vulnerabilities: expectedNestedAssetVulnerabilityDetails,
 	}


### PR DESCRIPTION
This change adds ScanTime to the incoming and outgoing asset event schema to support the new ScanTime, which represents the time the asset was scanned given a certain ScanID that from a completed scan