### PR TITLE
removed lastScanned from schema and struct field

### DIFF
--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -142,7 +142,7 @@ components:
         scanTime:
           type: string
           format: date-time
-          description: The time the asset was scanned.
+          description: The time the asset was scanned in ISO8601 format.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -168,7 +168,7 @@ components:
         scanTime:
           type: string
           format: date-time
-          description: The time the asset was scanned.
+          description: The time the asset was scanned in ISO8601 format.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.

--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -127,6 +127,7 @@ components:
       required:
         - id
         - ip
+        - scanTime
         - assetVulnerabilityDetails
       properties:
         id:
@@ -138,10 +139,6 @@ components:
           type: string
           example: 182.34.74.202
           description: The primary IPv4 or IPv6 address of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
         scanTime:
           type: string
           format: date-time
@@ -156,6 +153,7 @@ components:
       required:
         - id
         - hostname
+        - scanTime
         - assetVulnerabilityDetails
       properties:
         id:
@@ -167,11 +165,7 @@ components:
           type: string
           example: corporate-workstation-1102DC.acme.com
           description: The primary host name (local or FQDN) of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
-       scanTime:
+        scanTime:
           type: string
           format: date-time
           description: The time the asset was scanned.

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -127,7 +127,7 @@ components:
         scanTime:
           type: string
           format: date-time
-          description: The time the asset was scanned.
+          description: The time the asset was scanned in ISO8601 format.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -276,7 +276,7 @@ components:
         scanTime:
           type: string
           format: date-time
-          description: The time the asset was scanned.
+          description: The time the asset was scanned in ISO8601 format.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.
@@ -304,7 +304,7 @@ components:
         scanTime:
           type: string
           format: date-time
-          description: The time the asset was scanned.
+          description: The time the asset was scanned in ISO8601 format.
         assetVulnerabilityDetails:
           type: array
           description: List of vulnerabilities found on the asset.

--- a/gateway-outgoing.yaml
+++ b/gateway-outgoing.yaml
@@ -108,6 +108,7 @@ components:
       required:
         - id
         - ip
+        - scanTime
         - assetVulnerabilityDetails
       properties:
         hostname:
@@ -123,10 +124,6 @@ components:
           type: string
           example: 182.34.74.202
           description: The primary IPv4 or IPv6 address of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
         scanTime:
           type: string
           format: date-time
@@ -264,6 +261,7 @@ components:
       required:
         - id
         - ip
+        - scanTime
         - assetVulnerabilityDetails
       properties:
         id:
@@ -275,10 +273,6 @@ components:
           type: string
           example: 182.34.74.202
           description: The primary IPv4 or IPv6 address of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
         scanTime:
           type: string
           format: date-time
@@ -295,6 +289,7 @@ components:
       required:
         - id
         - hostname
+        - scanTime
         - assetVulnerabilityDetails
       properties:
         id:
@@ -306,10 +301,6 @@ components:
           type: string
           example: corporate-workstation-1102DC.acme.com
           description: The primary host name (local or FQDN) of the asset.
-        lastScanned:
-          type: string
-          format: date-time
-          description: The last time the asset was scanned.
         scanTime:
           type: string
           format: date-time

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -18,7 +18,6 @@ type AssetAttributor interface {
 // NexposeAssetVulnerabilities is a Nexpose asset response payload appended
 // with assetVulnerabilityDetails
 type NexposeAssetVulnerabilities struct {
-	LastScanned     time.Time                   `json:"lastScanned"`
 	ScanTime        time.Time                   `json:"scanTime"`
 	Hostname        string                      `json:"hostname"`
 	ID              int64                       `json:"id"`


### PR DESCRIPTION
This pr is to address the unresolved tasks in https://github.com/asecurityteam/nexpose-asset-attributor/pull/30/files.
- no need to add backwards compatibility in cloudassetinventory.go, this code is essentially a stub(see Mike's task in above PR^^)
- removed lastScanned in the outbound schema, made scanTime required
- removed lastScanned from struct `NexposeAssetVulnerabilities`
this pr should theoretically not effect production given we use v1.0.0 in production