### PR TITLE
Psd 393/add new attribution error

### DIFF
--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -95,13 +95,15 @@ paths:
               "status":
               #! if eq .Response.Body.errorType "AssetNotFoundError" !# 404,
               #! else if eq .Response.Body.errorType "AssetInventoryRequestError" !# 502,
-              #! else if eq .Response.Body.errorType "AssetInventoryMultipleAttributionErrors" !# 404,
+              #! else if eq .Response.Body.errorType "AssetInventoryMultipleAttributionErrors" !# 502,
               #! else !# 500,
               #! end !#
               "body": {
                 #! if eq .Response.Body.errorType "AssetNotFoundError" !#
                 "code": 404, "status": "Not Found",
                 #! else if eq .Response.Body.errorType "AssetInventoryRequestError" !#
+                "code": 502, "status": "Bad Gateway",
+                #! else if eq .Response.Body.errorType "AssetInventoryMultipleAttributionErrors" !#
                 "code": 502, "status": "Bad Gateway",
                 #! else !#
                 "code": 500, "status": "Internal Server Error",

--- a/gateway-incoming.yaml
+++ b/gateway-incoming.yaml
@@ -95,6 +95,7 @@ paths:
               "status":
               #! if eq .Response.Body.errorType "AssetNotFoundError" !# 404,
               #! else if eq .Response.Body.errorType "AssetInventoryRequestError" !# 502,
+              #! else if eq .Response.Body.errorType "AssetInventoryMultipleAttributionErrors" !# 404,
               #! else !# 500,
               #! end !#
               "body": {

--- a/pkg/assetattributor/cloudassetinventory.go
+++ b/pkg/assetattributor/cloudassetinventory.go
@@ -157,13 +157,12 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 		outerErrs = append(outerErrs, e)
 	}
 
-	// Exit with an AssetNotFoundError error if both API calls returned non-fatal errors.
+	// Exit with an AssetInventoryMultipleAttributionErrors error if both API calls returned non-fatal errors.
 	if len(outerErrs) == 2 {
-		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetNotFoundError{
-			Inner:          combinedError{Errors: outerErrs},
-			AssetID:        fmt.Sprintf("%d", asset.ID),
-			ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
-			AssetInventory: cloudAssetInventoryIdentifier,
+		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAttributionErrors{
+			Inner:         combinedError{Errors: outerErrs},
+			AssetID:       fmt.Sprintf("%d", asset.ID),
+			ScanTimestamp: asset.ScanTime.Format(time.RFC3339Nano),
 		}
 	}
 

--- a/pkg/assetattributor/cloudassetinventory.go
+++ b/pkg/assetattributor/cloudassetinventory.go
@@ -92,7 +92,6 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 	if asset.IP == "" && asset.Hostname == "" {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetNotFoundError{
 			Inner:          fmt.Errorf("asset has no IP or hostname"),
-			ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 			AssetInventory: cloudAssetInventoryIdentifier,
 		}
 	}
@@ -140,13 +139,11 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 		case httpMultipleAssetsFoundError:
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAssetsFoundError{
 				Inner:          e,
-				ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 				AssetInventory: cloudAssetInventoryIdentifier,
 			}
 		case httpBadRequest:
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryRequestError{
 				Inner:          e,
-				ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 				AssetInventory: cloudAssetInventoryIdentifier,
 				Code:           http.StatusBadRequest,
 			}
@@ -157,8 +154,7 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 	// Exit with an AssetInventoryMultipleAttributionErrors error if both API calls returned non-fatal errors.
 	if len(outerErrs) == 2 {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAttributionErrors{
-			Inner:         combinedError{Errors: outerErrs},
-			ScanTimestamp: asset.ScanTime.Format(time.RFC3339Nano),
+			Inner: combinedError{Errors: outerErrs},
 		}
 	}
 

--- a/pkg/assetattributor/cloudassetinventory.go
+++ b/pkg/assetattributor/cloudassetinventory.go
@@ -92,7 +92,6 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 	if asset.IP == "" && asset.Hostname == "" {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetNotFoundError{
 			Inner:          fmt.Errorf("asset has no IP or hostname"),
-			AssetID:        fmt.Sprintf("%d", asset.ID),
 			ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 			AssetInventory: cloudAssetInventoryIdentifier,
 		}
@@ -141,14 +140,12 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 		case httpMultipleAssetsFoundError:
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAssetsFoundError{
 				Inner:          e,
-				AssetID:        fmt.Sprintf("%d", asset.ID),
 				ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 				AssetInventory: cloudAssetInventoryIdentifier,
 			}
 		case httpBadRequest:
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryRequestError{
 				Inner:          e,
-				AssetID:        fmt.Sprintf("%d", asset.ID),
 				ScanTimestamp:  asset.ScanTime.Format(time.RFC3339Nano),
 				AssetInventory: cloudAssetInventoryIdentifier,
 				Code:           http.StatusBadRequest,
@@ -161,7 +158,6 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 	if len(outerErrs) == 2 {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAttributionErrors{
 			Inner:         combinedError{Errors: outerErrs},
-			AssetID:       fmt.Sprintf("%d", asset.ID),
 			ScanTimestamp: asset.ScanTime.Format(time.RFC3339Nano),
 		}
 	}

--- a/pkg/assetattributor/cloudassetinventory.go
+++ b/pkg/assetattributor/cloudassetinventory.go
@@ -85,14 +85,12 @@ type CloudAssetInventory struct {
 // Attribute queries the asecurityteam/asset-inventory-api service first by IP, then by hostname
 // if the first query returns no results
 func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.NexposeAssetVulnerabilities) (domain.NexposeAttributedAssetVulnerabilities, error) {
-	if asset.ScanTime.IsZero() {
-		return domain.NexposeAttributedAssetVulnerabilities{}, fmt.Errorf("no valid timestamp in scan history")
-	}
 
 	if asset.IP == "" && asset.Hostname == "" {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetNotFoundError{
 			Inner:          fmt.Errorf("asset has no IP or hostname"),
 			AssetInventory: cloudAssetInventoryIdentifier,
+			ScanTimestamp:  asset.ScanTime.String(),
 		}
 	}
 
@@ -140,12 +138,14 @@ func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.Nexpos
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryMultipleAssetsFoundError{
 				Inner:          e,
 				AssetInventory: cloudAssetInventoryIdentifier,
+				ScanTimestamp:  asset.ScanTime.String(),
 			}
 		case httpBadRequest:
 			return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetInventoryRequestError{
 				Inner:          e,
 				AssetInventory: cloudAssetInventoryIdentifier,
 				Code:           http.StatusBadRequest,
+				ScanTimestamp:  asset.ScanTime.String(),
 			}
 		}
 		outerErrs = append(outerErrs, e)

--- a/pkg/assetattributor/cloudassetinventory.go
+++ b/pkg/assetattributor/cloudassetinventory.go
@@ -85,7 +85,9 @@ type CloudAssetInventory struct {
 // Attribute queries the asecurityteam/asset-inventory-api service first by IP, then by hostname
 // if the first query returns no results
 func (n *CloudAssetInventory) Attribute(ctx context.Context, asset domain.NexposeAssetVulnerabilities) (domain.NexposeAttributedAssetVulnerabilities, error) {
-
+	if asset.ScanTime.IsZero() {
+		return domain.NexposeAttributedAssetVulnerabilities{}, fmt.Errorf("no valid timestamp in scan history")
+	}
 	if asset.IP == "" && asset.Hostname == "" {
 		return domain.NexposeAttributedAssetVulnerabilities{}, domain.AssetNotFoundError{
 			Inner:          fmt.Errorf("asset has no IP or hostname"),

--- a/pkg/assetattributor/cloudassetinventory_test.go
+++ b/pkg/assetattributor/cloudassetinventory_test.go
@@ -181,7 +181,7 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 			},
 			respCodes:   []int{http.StatusNotFound, http.StatusNotFound},
 			errExpected: true,
-			err:         domain.AssetNotFoundError{},
+			err:         domain.AssetInventoryMultipleAttributionErrors{},
 		},
 	}
 

--- a/pkg/assetattributor/cloudassetinventory_test.go
+++ b/pkg/assetattributor/cloudassetinventory_test.go
@@ -204,27 +204,6 @@ func TestCloudAssetInventory_Attribute(t *testing.T) {
 	}
 }
 
-func TestCloudAssetInventory_Attribute_InvalidAssetTimestamp(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockRT := NewMockRoundTripper(ctrl)
-	u, _ := url.Parse("http://localhost")
-
-	attributor := CloudAssetInventory{
-		Client:   &http.Client{Transport: mockRT},
-		Endpoint: u,
-	}
-
-	testAsset := domain.NexposeAssetVulnerabilities{
-		ID:       1,
-		ScanTime: time.Time{},
-		IP:       testIP,
-		Hostname: testHostname,
-	}
-	_, err := attributor.Attribute(context.Background(), testAsset)
-	require.Error(t, err)
-}
-
 func TestCloudAssetInventory_Attribute_NoHostnameOrIP(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -104,7 +104,7 @@ type AssetNotFoundError struct {
 
 func (err AssetNotFoundError) Error() string {
 	return fmt.Sprintf(
-		"Result not found for asset asset inventory %s: %v",
+		"Result not found for asset using asset inventory %s: %v",
 		err.AssetInventory, err.Inner)
 }
 

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -99,56 +99,52 @@ func (n *CloudAssetDetails) UnmarshalJSON(data []byte) error {
 // returns either a 404 Not Found response, or a 200 OK response with no results
 type AssetNotFoundError struct {
 	Inner          error
-	ScanTimestamp  string
 	AssetInventory string
 }
 
 func (err AssetNotFoundError) Error() string {
 	return fmt.Sprintf(
-		"Result not found for asset as of scan time %s in asset inventory %s: %v",
-		err.ScanTimestamp, err.AssetInventory, err.Inner)
+		"Result not found for asset asset inventory %s: %v",
+		err.AssetInventory, err.Inner)
 }
 
 // AssetInventoryRequestError occurs when a request to an asset inventory system
 // returns a failure response
 type AssetInventoryRequestError struct {
 	Inner          error
-	ScanTimestamp  string
 	AssetInventory string
 	Code           int
 }
 
 func (err AssetInventoryRequestError) Error() string {
 	return fmt.Sprintf(
-		"Request to asset inventory %s failed with code %d for asset as of scan time %s: %v",
-		err.AssetInventory, err.Code, err.ScanTimestamp, err.Inner)
+		"Request to asset inventory %s failed with code %d for asset: %v",
+		err.AssetInventory, err.Code, err.Inner)
 }
 
 // AssetInventoryMultipleAssetsFoundError occurs when a request to an asset inventory system
 // returns a successful response with multiple assets
 type AssetInventoryMultipleAssetsFoundError struct {
 	Inner          error
-	ScanTimestamp  string
 	AssetInventory string
 }
 
 func (err AssetInventoryMultipleAssetsFoundError) Error() string {
 	return fmt.Sprintf(
-		"Request to asset inventory %s returned multiple values for asset as of scan time %s: %v",
-		err.AssetInventory, err.ScanTimestamp, err.Inner)
+		"Request to asset inventory %s returned multiple values for asset: %v",
+		err.AssetInventory, err.Inner)
 }
 
 // AssetInventoryMultipleAttributionErrors occurs when multiple attribution errors
 // occur on multiple attribution sources
 type AssetInventoryMultipleAttributionErrors struct {
-	Inner         error
-	ScanTimestamp string
+	Inner error
 }
 
 func (err AssetInventoryMultipleAttributionErrors) Error() string {
 	return fmt.Sprintf(
-		"Multiple asset attribution sources returned errors on asset as of scan time %s: %v",
-		err.ScanTimestamp, err.Inner)
+		"Multiple asset attribution sources returned errors on asset: %v",
+		err.Inner)
 }
 
 // AttributionFailureHandler is an interface that handles assets that could not be completely

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -141,6 +141,20 @@ func (err AssetInventoryMultipleAssetsFoundError) Error() string {
 		err.AssetInventory, err.AssetID, err.ScanTimestamp, err.Inner)
 }
 
+// AssetInventoryMultipleAttributionErrors occurs when multiple attribution errors
+// occur on multiple attribution sources
+type AssetInventoryMultipleAttributionErrors struct {
+	Inner         error
+	AssetID       string
+	ScanTimestamp string
+}
+
+func (err AssetInventoryMultipleAttributionErrors) Error() string {
+	return fmt.Sprintf(
+		"Multiple asset attribution sources returned errors on asset ID %s as of scan time %s: %v",
+		err.AssetID, err.ScanTimestamp, err.Inner)
+}
+
 // AttributionFailureHandler is an interface that handles assets that could not be completely
 // attributed. The methods to implement might vary organization to organization
 type AttributionFailureHandler interface {

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"time"
 )
@@ -100,12 +99,12 @@ func (n *CloudAssetDetails) UnmarshalJSON(data []byte) error {
 type AssetNotFoundError struct {
 	Inner          error
 	AssetInventory string
+	Code           int
+	ScanTimestamp  string
 }
 
 func (err AssetNotFoundError) Error() string {
-	return fmt.Sprintf(
-		"Result not found for asset using asset inventory %s: %v",
-		err.AssetInventory, err.Inner)
+	return "Result not found for asset using asset inventory"
 }
 
 // AssetInventoryRequestError occurs when a request to an asset inventory system
@@ -114,12 +113,11 @@ type AssetInventoryRequestError struct {
 	Inner          error
 	AssetInventory string
 	Code           int
+	ScanTimestamp  string
 }
 
 func (err AssetInventoryRequestError) Error() string {
-	return fmt.Sprintf(
-		"Request to asset inventory %s failed with code %d for asset: %v",
-		err.AssetInventory, err.Code, err.Inner)
+	return "Request to asset inventory for asset"
 }
 
 // AssetInventoryMultipleAssetsFoundError occurs when a request to an asset inventory system
@@ -127,24 +125,23 @@ func (err AssetInventoryRequestError) Error() string {
 type AssetInventoryMultipleAssetsFoundError struct {
 	Inner          error
 	AssetInventory string
+	ScanTimestamp  string
 }
 
 func (err AssetInventoryMultipleAssetsFoundError) Error() string {
-	return fmt.Sprintf(
-		"Request to asset inventory %s returned multiple values for asset: %v",
-		err.AssetInventory, err.Inner)
+	return "Request to asset inventory %s returned multiple values for asset"
 }
 
 // AssetInventoryMultipleAttributionErrors occurs when multiple attribution errors
 // occur on multiple attribution sources
 type AssetInventoryMultipleAttributionErrors struct {
-	Inner error
+	Inner          error
+	ScanTimestamp  string
+	AssetInventory string
 }
 
 func (err AssetInventoryMultipleAttributionErrors) Error() string {
-	return fmt.Sprintf(
-		"Multiple asset attribution sources returned errors on asset: %v",
-		err.Inner)
+	return "Multiple asset attribution sources returned errors on asset"
 }
 
 // AttributionFailureHandler is an interface that handles assets that could not be completely

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -99,22 +99,20 @@ func (n *CloudAssetDetails) UnmarshalJSON(data []byte) error {
 // returns either a 404 Not Found response, or a 200 OK response with no results
 type AssetNotFoundError struct {
 	Inner          error
-	AssetID        string
 	ScanTimestamp  string
 	AssetInventory string
 }
 
 func (err AssetNotFoundError) Error() string {
 	return fmt.Sprintf(
-		"Result not found for asset with ID %s as of scan time %s in asset inventory %s: %v",
-		err.AssetID, err.ScanTimestamp, err.AssetInventory, err.Inner)
+		"Result not found for asset as of scan time %s in asset inventory %s: %v",
+		err.ScanTimestamp, err.AssetInventory, err.Inner)
 }
 
 // AssetInventoryRequestError occurs when a request to an asset inventory system
 // returns a failure response
 type AssetInventoryRequestError struct {
 	Inner          error
-	AssetID        string
 	ScanTimestamp  string
 	AssetInventory string
 	Code           int
@@ -122,37 +120,35 @@ type AssetInventoryRequestError struct {
 
 func (err AssetInventoryRequestError) Error() string {
 	return fmt.Sprintf(
-		"Request to asset inventory %s failed with code %d for asset with ID %s as of scan time %s: %v",
-		err.AssetInventory, err.Code, err.AssetID, err.ScanTimestamp, err.Inner)
+		"Request to asset inventory %s failed with code %d for asset as of scan time %s: %v",
+		err.AssetInventory, err.Code, err.ScanTimestamp, err.Inner)
 }
 
 // AssetInventoryMultipleAssetsFoundError occurs when a request to an asset inventory system
 // returns a successful response with multiple assets
 type AssetInventoryMultipleAssetsFoundError struct {
 	Inner          error
-	AssetID        string
 	ScanTimestamp  string
 	AssetInventory string
 }
 
 func (err AssetInventoryMultipleAssetsFoundError) Error() string {
 	return fmt.Sprintf(
-		"Request to asset inventory %s returned multiple values for asset with ID %s as of scan time %s: %v",
-		err.AssetInventory, err.AssetID, err.ScanTimestamp, err.Inner)
+		"Request to asset inventory %s returned multiple values for asset as of scan time %s: %v",
+		err.AssetInventory, err.ScanTimestamp, err.Inner)
 }
 
 // AssetInventoryMultipleAttributionErrors occurs when multiple attribution errors
 // occur on multiple attribution sources
 type AssetInventoryMultipleAttributionErrors struct {
 	Inner         error
-	AssetID       string
 	ScanTimestamp string
 }
 
 func (err AssetInventoryMultipleAttributionErrors) Error() string {
 	return fmt.Sprintf(
-		"Multiple asset attribution sources returned errors on asset ID %s as of scan time %s: %v",
-		err.AssetID, err.ScanTimestamp, err.Inner)
+		"Multiple asset attribution sources returned errors on asset as of scan time %s: %v",
+		err.ScanTimestamp, err.Inner)
 }
 
 // AttributionFailureHandler is an interface that handles assets that could not be completely

--- a/pkg/domain/attributor.go
+++ b/pkg/domain/attributor.go
@@ -104,7 +104,7 @@ type AssetNotFoundError struct {
 }
 
 func (err AssetNotFoundError) Error() string {
-	return "Result not found for asset using asset inventory"
+	return "result not found in asset inventory"
 }
 
 // AssetInventoryRequestError occurs when a request to an asset inventory system
@@ -117,7 +117,7 @@ type AssetInventoryRequestError struct {
 }
 
 func (err AssetInventoryRequestError) Error() string {
-	return "Request to asset inventory for asset"
+	return "request to asset inventory failed"
 }
 
 // AssetInventoryMultipleAssetsFoundError occurs when a request to an asset inventory system
@@ -129,7 +129,7 @@ type AssetInventoryMultipleAssetsFoundError struct {
 }
 
 func (err AssetInventoryMultipleAssetsFoundError) Error() string {
-	return "Request to asset inventory %s returned multiple values for asset"
+	return "request to asset inventory returned multiple values for asset"
 }
 
 // AssetInventoryMultipleAttributionErrors occurs when multiple attribution errors
@@ -141,7 +141,7 @@ type AssetInventoryMultipleAttributionErrors struct {
 }
 
 func (err AssetInventoryMultipleAttributionErrors) Error() string {
-	return "Multiple asset attribution sources returned errors on asset"
+	return "multiple asset attribution sources returned errors on asset"
 }
 
 // AttributionFailureHandler is an interface that handles assets that could not be completely

--- a/pkg/domain/attributor_test.go
+++ b/pkg/domain/attributor_test.go
@@ -77,7 +77,7 @@ func TestCustomUnmarshallingFull(t *testing.T) {
 		},
 	}
 
-	require.True(t, reflect.DeepEqual(expected, partial), "marshalled object does not equal expected object")
+	require.True(t, reflect.DeepEqual(expected, partial), "marshaled object does not equal expected object")
 }
 
 func TestCustomUnmarshallingEmpty(t *testing.T) {
@@ -104,9 +104,9 @@ func TestCustomUnmarshallingEmpty(t *testing.T) {
 	}
 
 	// kind of a dumb test... but good enough to see
-	marshalled, _ := json.Marshal(partial)
+	marshaled, _ := json.Marshal(partial)
 	badMarshalMsg := "You've added a new field in the struct hierarchy that is type array, slice, or map, but forgot to add custom unmarshalling logic for it"
-	require.False(t, strings.Contains(string(marshalled), "null"), badMarshalMsg)
+	require.False(t, strings.Contains(string(marshaled), "null"), badMarshalMsg)
 
-	require.True(t, reflect.DeepEqual(expected, partial), "marshalled object does not equal expected object")
+	require.True(t, reflect.DeepEqual(expected, partial), "marshaled object does not equal expected object")
 }

--- a/pkg/domain/attributor_test.go
+++ b/pkg/domain/attributor_test.go
@@ -110,3 +110,39 @@ func TestCustomUnmarshallingEmpty(t *testing.T) {
 
 	require.True(t, reflect.DeepEqual(expected, partial), "marshaled object does not equal expected object")
 }
+
+func TestErrors(t *testing.T) {
+
+	tc := []struct {
+		name           string
+		err            error
+		expectedString string
+	}{
+		{
+			name:           "AssetNotFoundError",
+			err:            &AssetNotFoundError{},
+			expectedString: "result not found in asset inventory",
+		},
+		{
+			name:           "AssetInventoryRequestError",
+			err:            &AssetInventoryRequestError{},
+			expectedString: "request to asset inventory failed",
+		},
+		{
+			name:           "AssetInventoryMultipleAssetsFoundError",
+			err:            &AssetInventoryMultipleAssetsFoundError{},
+			expectedString: "request to asset inventory returned multiple values for asset",
+		},
+		{
+			name:           "AssetInventoryMultipleAttributionErrors",
+			err:            &AssetInventoryMultipleAttributionErrors{},
+			expectedString: "multiple asset attribution sources returned errors on asset",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.err.Error(), tt.expectedString)
+		})
+	}
+}

--- a/pkg/handlers/v1/attribute.go
+++ b/pkg/handlers/v1/attribute.go
@@ -32,6 +32,8 @@ func (h *AttributeHandler) Handle(ctx context.Context, assetVulns domain.Nexpose
 			logger.Error(logs.AssetInventoryRequestError{Reason: attributionErr.Error(), AssetID: assetVulns.ID})
 		case domain.AssetInventoryMultipleAssetsFoundError:
 			logger.Error(logs.AssetInventoryMultipleAssetsFoundError{Reason: attributionErr.Error(), AssetID: assetVulns.ID})
+		case domain.AssetInventoryMultipleAttributionErrors:
+			logger.Error(logs.AssetInventoryMultipleAttributionErrors{Reason: attributionErr.Error(), AssetID: assetVulns.ID})
 		default:
 			logger.Error(logs.UnknownAttributionFailureError{Reason: attributionErr.Error(), AssetID: assetVulns.ID})
 		}

--- a/pkg/logs/assetattributor_error.go
+++ b/pkg/logs/assetattributor_error.go
@@ -48,15 +48,19 @@ type AssetInventoryMultipleAttributionErrors struct {
 // and returns a corresponding struct with logging information
 func AttributionErrorLogFactory(attributionErr error, assetID int64) interface{} {
 	switch attributionErr.(type) {
-	case domain.AssetNotFoundError:
-		return AssetNotFoundError{Reason: attributionErr.Error(), AssetID: assetID}
-	case domain.AssetInventoryRequestError:
-		return AssetInventoryRequestError{Reason: attributionErr.Error(), AssetID: assetID}
-	case domain.AssetInventoryMultipleAssetsFoundError:
-		return AssetInventoryMultipleAssetsFoundError{Reason: attributionErr.Error(), AssetID: assetID}
-	case domain.AssetInventoryMultipleAttributionErrors:
-		return AssetInventoryMultipleAttributionErrors{Reason: attributionErr.Error(), AssetID: assetID}
+	case *domain.AssetNotFoundError:
+		attributionErr := attributionErr.(domain.AssetNotFoundError)
+		return AssetNotFoundError{Message: attributionErr.Error(), Reason: attributionErr.Inner.Error(), AssetID: assetID}
+	case *domain.AssetInventoryRequestError:
+		attributionErr := attributionErr.(domain.AssetInventoryRequestError)
+		return AssetInventoryRequestError{Message: attributionErr.Error(), Reason: attributionErr.Inner.Error(), AssetID: assetID}
+	case *domain.AssetInventoryMultipleAssetsFoundError:
+		attributionErr := attributionErr.(domain.AssetInventoryMultipleAssetsFoundError)
+		return AssetInventoryMultipleAssetsFoundError{Message: attributionErr.Error(), Reason: attributionErr.Inner.Error(), AssetID: assetID}
+	case *domain.AssetInventoryMultipleAttributionErrors:
+		attributionErr := attributionErr.(domain.AssetInventoryMultipleAttributionErrors)
+		return AssetInventoryMultipleAttributionErrors{Message: attributionErr.Error(), Reason: attributionErr.Inner.Error(), AssetID: assetID}
 	default:
-		return UnknownAttributionFailureError{Reason: attributionErr.Error(), AssetID: assetID}
+		return UnknownAttributionFailureError{Message: attributionErr.Error(), AssetID: assetID}
 	}
 }

--- a/pkg/logs/assetattributor_error.go
+++ b/pkg/logs/assetattributor_error.go
@@ -32,3 +32,12 @@ type UnknownAttributionFailureError struct {
 	Reason  string `logevent:"reason,default=unknown-attribution-failure"`
 	AssetID int64  `logevent:"assetID,default=id-not-specified"`
 }
+
+// AssetInventoryMultipleAttributionErrors occurs when asset attribution fails due to
+// multiple sources of attribution. This error occurs as a result of a combination of the
+// above errors
+type AssetInventoryMultipleAttributionErrors struct {
+	Message string `logevent:"message,default=attribution-failure"`
+	Reason  string `logevent:"reason,default=asset-could-not-attribute-on-sources"`
+	AssetID int64  `logevent:"assetID,default=id-not-specified"`
+}

--- a/pkg/logs/assetattributor_error.go
+++ b/pkg/logs/assetattributor_error.go
@@ -1,5 +1,7 @@
 package logs
 
+import "github.com/asecurityteam/nexpose-asset-attributor/pkg/domain"
+
 // AssetNotFoundError occurs when asset attribution fails due to
 // either a 404 Not Found response or a 200 OK response with no results
 // from the queried asset inventory system(s)
@@ -40,4 +42,21 @@ type AssetInventoryMultipleAttributionErrors struct {
 	Message string `logevent:"message,default=attribution-failure"`
 	Reason  string `logevent:"reason,default=asset-could-not-attribute-on-sources"`
 	AssetID int64  `logevent:"assetID,default=id-not-specified"`
+}
+
+// AttributionErrorLogFactory is a factory function that takes an error that occurs during attribution,
+// and returns a corresponding struct with logging information
+func AttributionErrorLogFactory(attributionErr error, assetID int64) interface{} {
+	switch attributionErr.(type) {
+	case domain.AssetNotFoundError:
+		return AssetNotFoundError{Reason: attributionErr.Error(), AssetID: assetID}
+	case domain.AssetInventoryRequestError:
+		return AssetInventoryRequestError{Reason: attributionErr.Error(), AssetID: assetID}
+	case domain.AssetInventoryMultipleAssetsFoundError:
+		return AssetInventoryMultipleAssetsFoundError{Reason: attributionErr.Error(), AssetID: assetID}
+	case domain.AssetInventoryMultipleAttributionErrors:
+		return AssetInventoryMultipleAttributionErrors{Reason: attributionErr.Error(), AssetID: assetID}
+	default:
+		return UnknownAttributionFailureError{Reason: attributionErr.Error(), AssetID: assetID}
+	}
 }

--- a/pkg/logs/assetvalidator_error.go
+++ b/pkg/logs/assetvalidator_error.go
@@ -1,5 +1,7 @@
 package logs
 
+import "github.com/asecurityteam/nexpose-asset-attributor/pkg/domain"
+
 // AssetValidationFailure occurs when an asset was found in an asset inventory system
 // and subsequent validation of that asset completed, but with a failure result.
 type AssetValidationFailure struct {
@@ -14,4 +16,15 @@ type AssetValidationError struct {
 	Message string `logevent:"message,default=validation-error"`
 	Reason  string `logevent:"reason,default=unknown-validation-error"`
 	AssetID int64  `logevent:"assetID,default=id-not-specified"`
+}
+
+// ValidationErrorLogFactory is a factory function that takes an error that occurs during validation,
+// and returns a corresponding struct with logging information
+func ValidationErrorLogFactory(validationErr error, assetID int64) interface{} {
+	switch validationErr.(type) {
+	case domain.ValidationFailure:
+		return AssetValidationFailure{Reason: validationErr.Error(), AssetID: assetID}
+	default:
+		return AssetValidationError{Reason: validationErr.Error(), AssetID: assetID}
+	}
 }


### PR DESCRIPTION
This PR addresses PSD-393:
- We want a new error case for the instance that multiple attribution sources fail
- We don't want to use AssetNotFoundError, as it's name does not imply the new error case we are seeing within our code base
- We have a new error case that our handle logs, one for multiple attribution failures