### PR TITLE
Log ARN and resourcetype info for assets that fail validation.

### DIFF
--- a/pkg/handlers/v1/attribute.go
+++ b/pkg/handlers/v1/attribute.go
@@ -36,7 +36,7 @@ func (h *AttributeHandler) Handle(ctx context.Context, assetVulns domain.Nexpose
 	validationErr := h.AttributedAssetValidator.Validate(ctx, attributedAssetVulns)
 	if validationErr != nil {
 
-		logger.Error(logs.ValidationErrorLogFactory(validationErr, assetVulns.ID))
+		logger.Error(logs.ValidationErrorLogFactory(validationErr, assetVulns.ID, attributedAssetVulns.BusinessContext.ARN, attributedAssetVulns.BusinessContext.ResourceType))
 
 		failureHandlerErr := h.AttributionFailureHandler.HandleAttributionFailure(ctx, attributedAssetVulns, validationErr)
 		if failureHandlerErr != nil {

--- a/pkg/logs/assetvalidator_error.go
+++ b/pkg/logs/assetvalidator_error.go
@@ -5,9 +5,11 @@ import "github.com/asecurityteam/nexpose-asset-attributor/pkg/domain"
 // AssetValidationFailure occurs when an asset was found in an asset inventory system
 // and subsequent validation of that asset completed, but with a failure result.
 type AssetValidationFailure struct {
-	Message string `logevent:"message,default=validation-failure"`
-	Reason  string `logevent:"reason,default=unknown-validation-failure"`
-	AssetID int64  `logevent:"assetID,default=id-not-specified"`
+	Message      string `logevent:"message,default=validation-failure"`
+	Reason       string `logevent:"reason,default=unknown-validation-failure"`
+	AssetID      int64  `logevent:"assetID,default=id-not-specified"`
+	ARN          string `logevent:"arn,default=arn-not-specified"`
+	ResourceType string `logevent:"resourcetype,default=unknown-resourcetype"`
 }
 
 // AssetValidationError occurs when an asset was found in an asset inventory system
@@ -20,10 +22,10 @@ type AssetValidationError struct {
 
 // ValidationErrorLogFactory is a factory function that takes an error that occurs during validation,
 // and returns a corresponding struct with logging information
-func ValidationErrorLogFactory(validationErr error, assetID int64) interface{} {
+func ValidationErrorLogFactory(validationErr error, assetID int64, arn string, resourceType string) interface{} {
 	switch validationErr.(type) {
 	case domain.ValidationFailure:
-		return AssetValidationFailure{Reason: validationErr.Error(), AssetID: assetID}
+		return AssetValidationFailure{Reason: validationErr.Error(), AssetID: assetID, ARN: arn, ResourceType: resourceType}
 	default:
 		return AssetValidationError{Reason: validationErr.Error(), AssetID: assetID}
 	}


### PR DESCRIPTION
For assets that fail validation (for instance, not having a valid resource owner), this change will log their ARNs and resource types. This will make it easier to identify trends for which kinds of assets are failing validation most often.